### PR TITLE
Sites per subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Specify path to your Turtle-File in `_config.yml`:
 jekyll_rdf:
   path: "simpsons.ttl"
 ```
-Now, create the file "rdf-index.html" in _layouts - directory to edit the default layout for rdf-pages. See example below:
+Now, create the file "rdf_index.html" in _layouts - directory to edit the default layout for rdf-pages. See example below:
 
 ```html
 ---

--- a/README.md
+++ b/README.md
@@ -27,18 +27,31 @@ Specify path to your Turtle-File in `_config.yml`:
 jekyll_rdf:
   path: "simpsons.ttl"
 ```
-Now, you can access a collection of all RDF statements in your ERB templates:
+Now, create the file "rdf-index.html" in _layouts - directory to edit the default layout for rdf-pages. See example below:
 
 ```html
-<table>
-  {% for statement in site.data.rdf %}
-    <tr>
-      <td>{{ statement[0] }}</td> <!-- Subject -->
-      <td>{{ statement[1] }}</td> <!-- Predicate -->
-      <td>{{ statement[2] }}</td> <!-- Object -->
-    </tr>
-  {% endfor %}
-</table>
+---
+layout: default
+---
+
+<div class="home">
+
+  <h1 class="page-heading">{{ page.title }}</h1>
+
+  <table border="1">
+	  <tr><td>Subject</td><td>Predicate</td><td>Object</td></tr>
+    {% for statement in page.rdf %}
+      <tr>
+        <td>{{ statement[0] }}</td> <!-- Subject -->
+        <td>{{ statement[1] }}</td> <!-- Predicate -->
+        <td>{{ statement[2] }}</td> <!-- Object -->
+      </tr>
+    {% endfor %}
+  </table>
+
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+
+</div>
 ```
 
 # Development

--- a/lib/jekyll-rdf.rb
+++ b/lib/jekyll-rdf.rb
@@ -10,7 +10,27 @@ module JekyllRdf
   #
   # JekyllRdf::Generator enriches site.data with rdf triples
   #
-  class Generator < Jekyll::Generator
+  class RdfPageData < Jekyll::Page
+    def initialize(site, base, subject, graph)
+      @site = site
+      @base = base
+      @dir = "rdfsites" #todo
+      @name = subject.to_s + ".html"
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'rdf_index.html')
+      self.data['title'] = subject.to_s
+      graphedit = graph.query(:subject => subject)
+      self.data['rdf'] = graphedit.statements.map do |statement|
+      [
+        statement.subject.to_s,
+        statement.predicate.to_s,
+        statement.object.to_s
+      ]
+      end
+    end
+  end
+  
+  class MainGenerator < Jekyll::Generator
     safe true
     priority :highest
 
@@ -22,13 +42,10 @@ module JekyllRdf
     def generate(site)
       config = site.config.fetch('jekyll_rdf')
 
-      queryable = RDF::Repository.load(config['path'], format: :ttl)
-      site.data['rdf'] = queryable.statements.map do |statement|
-        [
-          statement.subject.to_s,
-          statement.predicate.to_s,
-          statement.object.to_s
-        ]
+      graph = RDF::Graph.load(config['path'])
+      
+      graph.subjects.each do |subject|
+        site.pages << RdfPageData.new(site, site.source, subject, graph)
       end
     end
   end

--- a/test/source/_layouts/rdf_index.html
+++ b/test/source/_layouts/rdf_index.html
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+
+<div class="home">
+
+  <h1 class="page-heading">{{ page.title }}</h1>
+
+  <table border="1">
+	  <tr><td>Subject</td><td>Predicate</td><td>Object</td></tr>
+    {% for statement in page.rdf %}
+      <tr>
+        <td>{{ statement[0] }}</td> <!-- Subject -->
+        <td>{{ statement[1] }}</td> <!-- Predicate -->
+        <td>{{ statement[2] }}</td> <!-- Object -->
+      </tr>
+    {% endfor %}
+  </table>
+
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+
+</div>

--- a/test/test_jekyll-rdf.rb
+++ b/test/test_jekyll-rdf.rb
@@ -17,31 +17,25 @@ class TestJekyllRdf < Test::Unit::TestCase
       'path' => "#{SOURCE_DIR}/rdf-data/simpsons.ttl"
     }
   }
+  config = Jekyll.configuration(TEST_OPTIONS)
+  site = Jekyll::Site.new(config)
+  site.process
+  pagearray = site.pages.select{|p| p.name == "http://www.ifi.uio.no/INF3580/simpsons#Homer.html"} # creates an array
+  homer_page = pagearray[0] # select first entry of selection
   
-  context "Generating a site with RDF data" do
-    config = Jekyll.configuration(TEST_OPTIONS)
-    site = Jekyll::Site.new(config)
-    site.process
-    
-    context "site data" do
-      should "create a file which mentions 'Lisa Simpson'" do
-        s = File.read("#{DEST_DIR}/rdfsites/http:/www.ifi.uio.no/INF3580/simpsons#Lisa.html")
-        expect(s).to include 'Lisa Simpson'
-      end
+  context "Generating a site with RDF data" do    
+    should "create a file which mentions 'Lisa Simpson'" do
+      s = File.read("#{DEST_DIR}/rdfsites/http:/www.ifi.uio.no/INF3580/simpsons#Lisa.html") # read static file
+      expect(s).to include 'Lisa Simpson'
     end
-  
-    context "Generate a page from RDF data" do
-      setup do
-        homer_page = site.pages.select{|p| p.name == "http://www.ifi.uio.no/INF3580/simpsons#Homer.html"}
-      end
-          
-      should "have rdf data" do
-        assert_not_nil(homer_page.rdf)
-      end
-    
-      should "contain correct age of Homer Simpson" do
+  end
+
+  context "Generate a page from RDF data" do
+    should "have rdf data" do
+      assert_not_nil(homer_page.data['rdf'])
+    end
+    should "contain correct age of Homer Simpson" do
         assert homer_page.data['rdf'].include?(['http://www.ifi.uio.no/INF3580/simpsons#Homer','http://xmlns.com/foaf/0.1/age','36'])
-      end
     end
   end
 

--- a/test/test_jekyll-rdf.rb
+++ b/test/test_jekyll-rdf.rb
@@ -22,20 +22,27 @@ class TestJekyllRdf < Test::Unit::TestCase
     config = Jekyll.configuration(TEST_OPTIONS)
     site = Jekyll::Site.new(config)
     site.process
-
-    should "have rdf data" do
-      assert_not_nil(site.data['rdf'])
-    end
     
-    should "contain correct age of Homer Simpson" do
-      assert site.data['rdf'].include?(['http://www.ifi.uio.no/INF3580/simpsons#Homer','http://xmlns.com/foaf/0.1/age','36'])
+    context "site data" do
+      should "create a file which mentions 'Lisa Simpson'" do
+        s = File.read("#{DEST_DIR}/rdfsites/http:/www.ifi.uio.no/INF3580/simpsons#Lisa.html")
+        expect(s).to include 'Lisa Simpson'
+      end
     end
-
-    should "create a file which mentions 'Lisa Simpson'" do
-      s = File.read("#{DEST_DIR}/index.html")
-      expect(s).to include 'Lisa Simpson'
+  
+    context "Generate a page from RDF data" do
+      setup do
+        homer_page = site.pages.select{|p| p.name == "http://www.ifi.uio.no/INF3580/simpsons#Homer.html"}
+      end
+          
+      should "have rdf data" do
+        assert_not_nil(homer_page.rdf)
+      end
+    
+      should "contain correct age of Homer Simpson" do
+        assert homer_page.data['rdf'].include?(['http://www.ifi.uio.no/INF3580/simpsons#Homer','http://xmlns.com/foaf/0.1/age','36'])
+      end
     end
-     
   end
 
 end


### PR DESCRIPTION
Jekyll-rdf now creates separate html resources for each subject. Default-Layout is rdf_index.html in _layouts directory. Test build passes :)